### PR TITLE
id_str may be None

### DIFF
--- a/ticketrelations/model.py
+++ b/ticketrelations/model.py
@@ -9,7 +9,7 @@ from trac.util.datefmt import utc, to_utimestamp
 
 def extract_ticket_ids(id_str):
     numbers_re = re.compile(r'\d+', re.U)
-    return set(int(n) for n in numbers_re.findall(id_str))
+    return set(int(n) for n in numbers_re.findall(id_str or ''))
 
 class TicketLinks(object):
     


### PR DESCRIPTION
With Postgres, when installing the plugin on an existing trac, the ticket_custom table is empty for values 'blocking', 'blockedby' and thus the plugin breaks when it receives a null value.
